### PR TITLE
Update to char-device 0.11 and socketpair 0.14.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/sunfishcode/duplex"
 exclude = ["/.github"]
 
 [dependencies]
-char-device = { version = "0.10.0", optional = true }
+char-device = { version = "0.11.0", optional = true }
 duplexify = { version = "1.2.2", optional = true }
 futures-io = { version = "0.3.12", optional = true }
 tokio = { version = "1.8.1", optional = true }
@@ -20,7 +20,7 @@ readwrite = { version = "0.2.0", optional = true }
 # [here]: https://gitlab.com/susurrus/serialport-rs#dependencies
 serialport = { version = "4.0.1", optional = true }
 ssh2 = { version = "0.9.1", optional = true }
-socketpair = { version = "0.13.0", optional = true }
+socketpair = { version = "0.14.0", optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
These update to io-lifetimes 0.5.